### PR TITLE
SUPPORT-53161 Added cancel URI to getTransferSignRedirectUri  method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.4.1
+- Added optional `cancel_url` argument to `Paysera_WalletApi_OAuth_Consumer::getTransferSignRedirectUri`, which appends its value as query parameter to resulting redirect uri
+
 ## 2.4.0
 - Added endpoint to revoke access token
 

--- a/src/Paysera/WalletApi/OAuth/Consumer.php
+++ b/src/Paysera/WalletApi/OAuth/Consumer.php
@@ -154,10 +154,11 @@ class Paysera_WalletApi_OAuth_Consumer
      *
      * @param string $transferId
      * @param string $redirectUri
+     * @param string $cancelUri
      *
      * @return string
      */
-    public function getTransferSignRedirectUri($transferId, $redirectUri = null)
+    public function getTransferSignRedirectUri($transferId, $redirectUri = null, $cancelUri = null)
     {
         if ($redirectUri === null) {
             $redirectUri = $this->getCurrentUri();
@@ -167,7 +168,10 @@ class Paysera_WalletApi_OAuth_Consumer
             '%s/%s?%s',
             $this->router->getAuthEndpoint('/wallet/transfer-sign'),
             urlencode($transferId),
-            http_build_query(['redirect_uri' => $redirectUri])
+            http_build_query([
+                'redirect_uri' => $redirectUri,
+                'cancel_uri' => $cancelUri,
+            ])
         );
     }
 


### PR DESCRIPTION
Added optional `$cancelUri` url parameter to `getTransferSignRedirectUri` method.

Currently, if the customer clicks "Cancel" button at the "transaction sign" page, he is being redirected to the "redirectUrl", 
 the same one, that is used for success redirect. Which is not correct for the case of woocommerce psd2 plugin integration, where order is being confirmed even if customer press "cancel"

So, the idea is to add another `cancel_url` url to redirect user in case he presses "Cancel"