### PR TITLE
REENG-1233 Add owner type to wallet account entity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.7.4
+## 2.8.0
 - Added owner type to wallet account entity
 
 ## 2.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.7.4
+- Added owner type to wallet account entity
+
 ## 2.7.3
 - Fixed decodeTime validation
 

--- a/src/Paysera/WalletApi/Entity/Wallet/Account.php
+++ b/src/Paysera/WalletApi/Entity/Wallet/Account.php
@@ -5,11 +5,20 @@
  */
 class Paysera_WalletApi_Entity_Wallet_Account
 {
+    const TYPE_LOCAL = 'local';
+    const TYPE_CARD = 'card';
+
     /**
      * @var string
      * @readonly
      */
     protected $number;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    protected $ownerType;
 
     /**
      * @var string|null
@@ -78,6 +87,15 @@ class Paysera_WalletApi_Entity_Wallet_Account
     {
         return $this->number;
     }
+
+    /**
+     * @return string|null
+     */
+    public function getOwnerType()
+    {
+        return $this->ownerType;
+    }
+
 
     /**
      * @return string|null

--- a/src/Paysera/WalletApi/Mapper.php
+++ b/src/Paysera/WalletApi/Mapper.php
@@ -1221,6 +1221,9 @@ class Paysera_WalletApi_Mapper
         $account = new Paysera_WalletApi_Entity_Wallet_Account();
 
         $this->setProperty($account, 'number', $data['number']);
+        if (isset($data['owner_type'])) {
+            $this->setProperty($account, 'ownerType', $data['owner_type']);
+        }
         if (isset($data['owner_title'])) {
             $this->setProperty($account, 'ownerTitle', $data['owner_title']);
         }


### PR DESCRIPTION
- Add an owner type field to the wallet account entity
- Update decode account mapper to set owner type
- Add constants for account types in the wallet account entity