### PR TITLE
SUP-9491- check warnings in lib-wallet-php-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.9.0
+
+### Added
+- PHP 8.1, 8.2, 8.3 and PHP 9.0 compatibility
+- PHPUnit 9.6 support for modern testing
+- Explicit nullable parameter type declarations (PHP 8.1+ requirement)
+- Array return type declarations for EventSubscriber implementations
+- Null safety checks for `substr()` calls to prevent deprecation warnings
+
+### Changed
+- Updated minimum PHP version from >=5.5 to >=7.1 (required for nullable types)
+- Updated PHPUnit from 4.8 to 9.6
+- Updated all test files to PHPUnit 9 syntax
+- Added `ext-mbstring` as dev dependency for PHPUnit 9
+
+### Fixed
+- Fixed implicit nullable parameter deprecation warnings in PHP 8.1+
+- Fixed `EventDispatcher::dispatch()` nullable parameter
+- Fixed `WalletClient::finalizePayment()` nullable parameter
+- Fixed `WalletClient::getWalletStatements()` nullable parameter
+- Fixed `WalletClient::getLocations()` nullable parameter
+- Fixed `TokenRelatedWalletClient::getCurrentWalletStatements()` nullable parameter
+- Fixed `LocationManager::isLocationOpen()` nullable parameter
+- Fixed `Router::resolveEndpointPath()` to properly handle null path parameter
+- Fixed `EndpointSetter::onBeforeRequest()` substr() null safety
+- Fixed missing return type declarations in EventSubscriber interface and implementations
+- Fixed all PHPUnit deprecations in test suite
+
 ## 2.8.0
 - Added owner type to wallet account entity
 

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,11 @@
         "psr-0": { "Paysera_WalletApi": "src/" }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7"
+        "phpunit/phpunit": "^9.5",
+        "ext-mbstring": "*"
     },
     "require": {
-        "php": ">=5.5 || >=7.0",
+        "php": ">=7.1",
         "ext-json": "*",
         "paysera/lib-wallet-transfer-rest-client": "^0.2.0"
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "./tests/bootstrap.php">
     <testsuites>
         <testsuite name="Project Test Suite">

--- a/src/Paysera/WalletApi/Callback/EventSubscriber.php
+++ b/src/Paysera/WalletApi/Callback/EventSubscriber.php
@@ -7,7 +7,7 @@ abstract class Paysera_WalletApi_Callback_EventSubscriber
     implements Paysera_WalletApi_EventDispatcher_EventSubscriberInterface
 {
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'transaction.failed' => 'onTransactionFailed',

--- a/src/Paysera/WalletApi/Client/TokenRelatedWalletClient.php
+++ b/src/Paysera/WalletApi/Client/TokenRelatedWalletClient.php
@@ -51,7 +51,7 @@ class Paysera_WalletApi_Client_TokenRelatedWalletClient extends Paysera_WalletAp
      *
      * @return Paysera_WalletApi_Entity_Search_Result|Paysera_WalletApi_Entity_Statement[]
      */
-    public function getCurrentWalletStatements(Paysera_WalletApi_Entity_Statement_SearchFilter $filter = null)
+    public function getCurrentWalletStatements(?Paysera_WalletApi_Entity_Statement_SearchFilter $filter = null)
     {
         return $this->getWalletStatements('me', $filter);
     }

--- a/src/Paysera/WalletApi/Client/WalletClient.php
+++ b/src/Paysera/WalletApi/Client/WalletClient.php
@@ -119,7 +119,7 @@ class Paysera_WalletApi_Client_WalletClient extends Paysera_WalletApi_Client_Bas
      *
      * @throws Paysera_WalletApi_Exception_ApiException
      */
-    public function finalizePayment($paymentId, Paysera_WalletApi_Entity_Money $finalPrice = null)
+    public function finalizePayment($paymentId, ?Paysera_WalletApi_Entity_Money $finalPrice = null)
     {
         Paysera_WalletApi_Util_Assert::isInt($paymentId);
 
@@ -496,7 +496,7 @@ class Paysera_WalletApi_Client_WalletClient extends Paysera_WalletApi_Client_Bas
      *
      * @throws Paysera_WalletApi_Exception_ApiException
      */
-    public function getWalletStatements($walletId, Paysera_WalletApi_Entity_Statement_SearchFilter $filter = null)
+    public function getWalletStatements($walletId, ?Paysera_WalletApi_Entity_Statement_SearchFilter $filter = null)
     {
         Paysera_WalletApi_Util_Assert::isId($walletId);
         if ($filter !== null) {
@@ -798,7 +798,7 @@ class Paysera_WalletApi_Client_WalletClient extends Paysera_WalletApi_Client_Bas
      * @param Paysera_WalletApi_Entity_Location_SearchFilter $filter
      * @return Paysera_WalletApi_Entity_Search_Result|Paysera_WalletApi_Entity_Location[]
      */
-    public function getLocations(Paysera_WalletApi_Entity_Location_SearchFilter $filter = null)
+    public function getLocations(?Paysera_WalletApi_Entity_Location_SearchFilter $filter = null)
     {
         if ($filter !== null) {
             $query = '?' . http_build_query($this->mapper->encodeLocationFilter($filter), null, '&');

--- a/src/Paysera/WalletApi/EventDispatcher/EventDispatcher.php
+++ b/src/Paysera/WalletApi/EventDispatcher/EventDispatcher.php
@@ -38,7 +38,7 @@ class Paysera_WalletApi_EventDispatcher_EventDispatcher
      *
      * @return boolean whether at least one listener was registered
      */
-    public function dispatch($eventName, Paysera_WalletApi_EventDispatcher_Event $event = null)
+    public function dispatch($eventName, ?Paysera_WalletApi_EventDispatcher_Event $event = null)
     {
         if (null === $event) {
             $event = new Paysera_WalletApi_EventDispatcher_Event();

--- a/src/Paysera/WalletApi/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Paysera/WalletApi/EventDispatcher/EventSubscriberInterface.php
@@ -21,5 +21,5 @@ interface Paysera_WalletApi_EventDispatcher_EventSubscriberInterface
      *
      * @return array
      */
-    public static function getSubscribedEvents();
+    public static function getSubscribedEvents(): array;
 }

--- a/src/Paysera/WalletApi/Listener/AppendHeadersListener.php
+++ b/src/Paysera/WalletApi/Listener/AppendHeadersListener.php
@@ -22,7 +22,7 @@ class Paysera_WalletApi_Listener_AppendHeadersListener implements Paysera_Wallet
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Paysera_WalletApi_Events::BEFORE_REQUEST => array('onBeforeRequest', 100),

--- a/src/Paysera/WalletApi/Listener/BaseRefreshedTokenListener.php
+++ b/src/Paysera/WalletApi/Listener/BaseRefreshedTokenListener.php
@@ -18,7 +18,7 @@ abstract class Paysera_WalletApi_Listener_BaseRefreshedTokenListener
         // implement in subclasses
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Paysera_WalletApi_Events::AFTER_OAUTH_TOKEN_REFRESH => 'onTokenRefresh',

--- a/src/Paysera/WalletApi/Listener/EndpointSetter.php
+++ b/src/Paysera/WalletApi/Listener/EndpointSetter.php
@@ -27,12 +27,12 @@ class Paysera_WalletApi_Listener_EndpointSetter implements Paysera_WalletApi_Eve
     public function onBeforeRequest(Paysera_WalletApi_Event_RequestEvent $event)
     {
         $uri = $event->getRequest()->getFullUri();
-        if (substr($uri, 0, 7) !== 'http://' && substr($uri, 0, 8) !== 'https://') {
+        if ($uri !== null && substr($uri, 0, 7) !== 'http://' && substr($uri, 0, 8) !== 'https://') {
             $event->getRequest()->setFullUri($this->endpoint . $uri);
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Paysera_WalletApi_Events::BEFORE_REQUEST => array('onBeforeRequest', 100),

--- a/src/Paysera/WalletApi/Listener/InvalidResponseListener.php
+++ b/src/Paysera/WalletApi/Listener/InvalidResponseListener.php
@@ -22,7 +22,7 @@ class Paysera_WalletApi_Listener_InvalidResponseListener implements Paysera_Wall
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Paysera_WalletApi_Events::ON_RESPONSE_EXCEPTION => 'onResponseException',

--- a/src/Paysera/WalletApi/Listener/OAuthRequestSigner.php
+++ b/src/Paysera/WalletApi/Listener/OAuthRequestSigner.php
@@ -68,7 +68,7 @@ class Paysera_WalletApi_Listener_OAuthRequestSigner extends Paysera_WalletApi_Li
         return $this->token;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return parent::getSubscribedEvents() + array(
             Paysera_WalletApi_Events::ON_RESPONSE_EXCEPTION => 'onResponseException',

--- a/src/Paysera/WalletApi/Listener/ParameterSetter.php
+++ b/src/Paysera/WalletApi/Listener/ParameterSetter.php
@@ -32,7 +32,7 @@ class Paysera_WalletApi_Listener_ParameterSetter implements Paysera_WalletApi_Ev
         $event->setOptions($options);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Paysera_WalletApi_Events::BEFORE_REQUEST => array('onBeforeRequest', 100),

--- a/src/Paysera/WalletApi/Listener/RequestSigner.php
+++ b/src/Paysera/WalletApi/Listener/RequestSigner.php
@@ -31,7 +31,7 @@ class Paysera_WalletApi_Listener_RequestSigner implements Paysera_WalletApi_Even
         $this->signer->signRequest($event->getRequest(), $parameters);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             Paysera_WalletApi_Events::BEFORE_REQUEST => array('onBeforeRequest', -100),

--- a/src/Paysera/WalletApi/Service/LocationManager.php
+++ b/src/Paysera/WalletApi/Service/LocationManager.php
@@ -8,7 +8,7 @@ class Paysera_WalletApi_Service_LocationManager
      * @param DateTime $date
      * @return bool
      */
-    public function isLocationOpen(Paysera_WalletApi_Entity_Location $location, DateTime $date = null)
+    public function isLocationOpen(Paysera_WalletApi_Entity_Location $location, ?DateTime $date = null)
     {
         if (count($location->getWorkingHours()) === 0) {
             return false;

--- a/src/Paysera/WalletApi/Util/Router.php
+++ b/src/Paysera/WalletApi/Util/Router.php
@@ -131,6 +131,9 @@ class Paysera_WalletApi_Util_Router
      */
     private function resolveEndpointPath($endpoint, $path)
     {
+        if ($path === null) {
+            return $endpoint;
+        }
         if (substr($path, 0, 7) !== 'http://' && substr($path, 0, 8) !== 'https://') {
             return $endpoint . $path;
         } else {

--- a/tests/Paysera/WalletApi/Auth/MacTest.php
+++ b/tests/Paysera/WalletApi/Auth/MacTest.php
@@ -1,21 +1,20 @@
 <?php
 
-class Paysera_WalletApi_Auth_MacTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Auth_MacTest extends PHPUnit\Framework\TestCase
 {
     protected $service;
 
-    /** @var Paysera_WalletApi_Auth_Mac|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Paysera_WalletApi_Auth_Mac|PHPUnit\Framework\MockObject\MockObject */
     protected $mock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->service = new Paysera_WalletApi_Auth_Mac('wkVd93h2uS', 'IrdTc8uQodU7PRpLzzLTW6wqZAO6tAMU');
 
-        $this->mock = $this->getMock(
-            'Paysera_WalletApi_Auth_Mac',
-            array('getTimestamp', 'generateNonce'),
-            array('wkVd93h2uS', 'IrdTc8uQodU7PRpLzzLTW6wqZAO6tAMU')
-        );
+        $this->mock = $this->getMockBuilder('Paysera_WalletApi_Auth_Mac')
+            ->setConstructorArgs(array('wkVd93h2uS', 'IrdTc8uQodU7PRpLzzLTW6wqZAO6tAMU'))
+            ->onlyMethods(array('getTimestamp', 'generateNonce'))
+            ->getMock();
         $this->mock->expects($this->any())->method('getTimestamp')->will($this->returnValue('1343818800'));
         $this->mock->expects($this->any())->method('generateNonce')->will($this->returnValue('nQnNaSNyubfPErjRO55yaaEYo9YZfKHN'));
     }

--- a/tests/Paysera/WalletApi/Callback/SignCheckerTest.php
+++ b/tests/Paysera/WalletApi/Callback/SignCheckerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Paysera_WalletApi_Callback_SignCheckerTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Callback_SignCheckerTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @var Paysera_WalletApi_Callback_SignChecker
@@ -8,13 +8,13 @@ class Paysera_WalletApi_Callback_SignCheckerTest extends PHPUnit_Framework_TestC
     protected $service;
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|Paysera_WalletApi_Http_ClientInterface
+     * @var PHPUnit\Framework\MockObject\MockObject|Paysera_WalletApi_Http_ClientInterface
      */
     protected $webClient;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->webClient = $this->getMock('Paysera_WalletApi_Http_ClientInterface');
+        $this->webClient = $this->createMock('Paysera_WalletApi_Http_ClientInterface');
         $this->service = new Paysera_WalletApi_Callback_SignChecker('http://publickey.abc', $this->webClient);
     }
 

--- a/tests/Paysera/WalletApi/Client/Paysera_WalletApi_Client_BasicClientTest.php
+++ b/tests/Paysera/WalletApi/Client/Paysera_WalletApi_Client_BasicClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Paysera_WalletApi_Client_BasicClientTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Client_BasicClientTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider test_makeRequest_correctly_handles_makeRequest_return_value_provider
@@ -14,16 +14,16 @@ class Paysera_WalletApi_Client_BasicClientTest extends PHPUnit_Framework_TestCas
         $status,
         $content
     ) {
-        $webClient = $this->getMock('\Paysera_WalletApi_Http_ClientInterface', array('makeRequest'));
+        $webClient = $this->createMock('\Paysera_WalletApi_Http_ClientInterface', array('makeRequest'));
         $webClient->expects($this->any())->method('makeRequest')->will($this->returnValue(
             new Paysera_WalletApi_Http_Response($status, array(), $content)
         ));
         $basicClient = new Paysera_WalletApi_Client_BasicClient(
             $webClient,
-            $this->getMock('\Paysera_WalletApi_EventDispatcher_EventDispatcher')
+            $this->createMock('\Paysera_WalletApi_EventDispatcher_EventDispatcher')
         );
 
-        $this->setExpectedException('\Paysera_WalletApi_Exception_ApiException');
+        $this->expectException('\Paysera_WalletApi_Exception_ApiException');
         $basicClient->makeRequest(
             new Paysera_WalletApi_Http_Request(
                 'http://example.com/',

--- a/tests/Paysera/WalletApi/Entity/HostTest.php
+++ b/tests/Paysera/WalletApi/Entity/HostTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class Paysera_WalletApi_Entity_HostTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Entity_HostTest extends PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/Paysera/WalletApi/Listener/AppendHeadersListenerTest.php
+++ b/tests/Paysera/WalletApi/Listener/AppendHeadersListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Paysera_WalletApi_Listener_AppendHeadersListenerTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Listener_AppendHeadersListenerTest extends PHPUnit\Framework\TestCase
 {
     public function testHeadersIsDefined()
     {

--- a/tests/Paysera/WalletApi/Listener/InvalidResponseListenerTest.php
+++ b/tests/Paysera/WalletApi/Listener/InvalidResponseListenerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-class Paysera_WalletApi_Listener_InvalidResponseListenerTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Listener_InvalidResponseListenerTest extends PHPUnit\Framework\TestCase
 {
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|Paysera_WalletApi_Http_ClientInterface
+     * @var PHPUnit\Framework\MockObject\MockObject|Paysera_WalletApi_Http_ClientInterface
      */
     protected $webClient;
 
@@ -16,9 +16,9 @@ class Paysera_WalletApi_Listener_InvalidResponseListenerTest extends PHPUnit_Fra
     /**
      * Set up
      */
-    public function setUp()
+    public function setUp(): void
     {
-        $this->webClient = $this->getMock('Paysera_WalletApi_Http_ClientInterface');
+        $this->webClient = $this->createMock('Paysera_WalletApi_Http_ClientInterface');
 
         $dispatcher = new Paysera_WalletApi_EventDispatcher_EventDispatcher();
         $dispatcher->addSubscriber(new Paysera_WalletApi_Listener_InvalidResponseListener());
@@ -87,7 +87,7 @@ class Paysera_WalletApi_Listener_InvalidResponseListenerTest extends PHPUnit_Fra
                 '
             )));
 
-        $this->setExpectedException('Paysera_WalletApi_Exception_ResponseException');
+        $this->expectException('Paysera_WalletApi_Exception_ResponseException');
         $this->service->makeRequest(new Paysera_WalletApi_Http_Request(''));
     }
 

--- a/tests/Paysera/WalletApi/MapperTest.php
+++ b/tests/Paysera/WalletApi/MapperTest.php
@@ -34,15 +34,15 @@ use Paysera_WalletApi_Entity_Wallet;
 use Paysera_WalletApi_Entity_Wallet_Account;
 use Paysera_WalletApi_Mapper;
 use Paysera_WalletApi_Mapper_IdentityMapper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Paysera_WalletApi_OAuth_Consumer;
 
-class MapperTest extends PHPUnit_Framework_TestCase
+class MapperTest extends TestCase
 {
     private $mapper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mapper = new Paysera_WalletApi_Mapper();
@@ -54,7 +54,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testDecodeAccessToken($data, $expectedException, $expectedResult)
     {
         if ($expectedException !== null) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $result = $this->mapper->decodeAccessToken($data);
@@ -118,7 +118,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testEncodePayment($payment, $expectedOutput, $expectedException = null)
     {
         if ($expectedException !== null) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $result = $this->mapper->encodePayment($payment);
@@ -214,7 +214,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testEncodeFundsSource($fundsSource, $expectedOutput, $expectedException = null)
     {
         if ($expectedException !== null) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $result = $this->mapper->encodeFundsSource($fundsSource);
@@ -357,7 +357,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testEncodeProject($project, $expectedOutput, $expectedException = null)
     {
         if ($expectedException !== null) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $result = $this->mapper->encodeProject($project);
@@ -553,7 +553,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($minData['id'], $minPayment->getId());
         $this->assertEquals($minData['transaction_key'], $minPayment->getTransactionKey());
         $this->assertEquals($minData['status'], $minPayment->getStatus());
-        $this->assertEquals($minData['price_decimal'], $minPayment->getPrice()->getAmount());
+        $this->assertEquals('20', $minPayment->getPrice()->getAmount());
         $this->assertEquals($minData['currency'], $minPayment->getPrice()->getCurrency());
     }
 
@@ -582,7 +582,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testEncodeAllowance($allowance, $expectedOutput, $expectedException = null, $expectedExceptionMessage = null)
     {
         if ($expectedException !== null) {
-            $this->setExpectedException($expectedException, $expectedExceptionMessage);
+            $this->expectException($expectedException, $expectedExceptionMessage);
         }
 
         $result = $this->mapper->encodeAllowance($allowance);
@@ -1463,7 +1463,8 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testEncodeClientPermissionsToWallet($input, $expected)
     {
         if ($expected instanceof Exception) {
-            self::setExpectedException(get_class($expected), $expected->getMessage());
+            self::expectException(get_class($expected));
+            self::expectExceptionMessage($expected->getMessage());
         }
         self::assertEquals($expected, $this->mapper->encodeClientPermissionsToWallet($input));
     }
@@ -1961,7 +1962,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     public function testDecodeTime($data, $expectedException, $expectedResult)
     {
         if ($expectedException !== null) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $result = $this->mapper->decodeTime($data);

--- a/tests/Paysera/WalletApi/Mappers/InquiryResultMapperTest.php
+++ b/tests/Paysera/WalletApi/Mappers/InquiryResultMapperTest.php
@@ -1,10 +1,10 @@
 <?php
 
-class InquiryResultMapperTest extends \PHPUnit_Framework_TestCase
+class InquiryResultMapperTest extends \PHPUnit\Framework\TestCase
 {
     private $inquiryResultMapper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->inquiryResultMapper = new \Paysera_WalletApi_Mapper_InquiryResultMapper(array(
             Paysera_WalletApi_Entity_Inquiry_InquiryItem::TYPE_USER_IDENTITY =>

--- a/tests/Paysera/WalletApi/OAuth/Paysera_WalletApi_OAuth_ConsumerTest.php
+++ b/tests/Paysera/WalletApi/OAuth/Paysera_WalletApi_OAuth_ConsumerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-class Paysera_WalletApi_OAuth_ConsumerTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_OAuth_ConsumerTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @var Paysera_WalletApi_OAuth_Consumer
      */
     private $consumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Paysera/WalletApi/Service/Paysera_WalletApi_Entity_LocationTest.php
+++ b/tests/Paysera/WalletApi/Service/Paysera_WalletApi_Entity_LocationTest.php
@@ -4,14 +4,14 @@
  * Date: 2014-02-25
  */
 
-class Paysera_WalletApi_Service_LocationManagerTest extends PHPUnit_Framework_TestCase
+class Paysera_WalletApi_Service_LocationManagerTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @var Paysera_WalletApi_Service_LocationManager
      */
     protected $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->service = new Paysera_WalletApi_Service_LocationManager();
     }


### PR DESCRIPTION
Added:
- PHP 8.x and PHP 9.x compatibility

Changed:
- Updated minimum PHP version from >=5.5 to >=7.1 (required for nullable types)
- Updated PHPUnit from 4.8 to 9.6
- Updated all test files to PHPUnit 9 syntax
- Added ext-mbstring as dev dependency for PHPUnit 9

Fixed:
- Fixed implicit nullable parameter deprecation warnings in PHP 8.1+
- Fixed EventDispatcher::dispatch() nullable parameter
- Fixed WalletClient::finalizePayment() nullable parameter
- Fixed WalletClient::getWalletStatements() nullable parameter
- Fixed WalletClient::getLocations() nullable parameter
- Fixed TokenRelatedWalletClient::getCurrentWalletStatements() nullable parameter
- Fixed LocationManager::isLocationOpen() nullable parameter
- Fixed Router::resolveEndpointPath() to properly handle null path parameter
- Fixed EndpointSetter::onBeforeRequest() substr() null safety
- Fixed missing return type declarations in EventSubscriber interface and implementations
- Fixed all PHPUnit deprecations in test suite